### PR TITLE
[nl]: Remove ZWSP characters

### DIFF
--- a/locales/nl/php.json
+++ b/locales/nl/php.json
@@ -97,7 +97,7 @@
     "tags": "Labels",
     "target_link.blank": "Open in een nieuw venster",
     "target_link.parent": "Open in een bovenliggend frame",
-    "target_link.self": "Open in een huidig ​​venster",
+    "target_link.self": "Open in een huidig venster",
     "target_link.top": "Open in het bovenste frame",
     "translate": "Vertalen",
     "translate_it": "Vertaal het",


### PR DESCRIPTION
It's hard to see in the web UI, but some update added ZWSP characters. I assume they aren't meant to be there, so I removed them.

<img width="1377" height="244" alt="image" src="https://github.com/user-attachments/assets/25fd6750-907a-46a1-9f07-9e1c19e057bb" />
