### PR TITLE
[sk]: Fix Show translation

### DIFF
--- a/locales/sk/json.json
+++ b/locales/sk/json.json
@@ -84,7 +84,7 @@
     "Select All": "Vybrať všetko",
     "Send": "Odoslať",
     "Settings": "nastavenie",
-    "Show": "Šou",
+    "Show": "Ukázať",
     "Show :name": "Ukázať :name",
     "Show All": "Ukázať všetko",
     "Sign In": "Prihlásiť sa",

--- a/locales/sk/php.json
+++ b/locales/sk/php.json
@@ -83,7 +83,7 @@
     "select_all": "Vybrať všetko",
     "send": "Odoslať",
     "settings": "nastavenie",
-    "show": "Šou",
+    "show": "Ukázať",
     "show_all": "Ukázať všetko",
     "sign_in": "Prihlásiť sa",
     "solve": "Riešiť",


### PR DESCRIPTION
## Summary
- Corrects Slovak `Show` / `show` from `Šou` (entertainment show) to `Ukázať` (display).
- Matches existing `Show All` / `show_all` (`Ukázať všetko`) and `Show :name` (`Ukázať :name`).

## Test plan
- [ ] Confirm `locales/sk/json.json` and `locales/sk/php.json` both use `Ukázať`.


Made with [Cursor](https://cursor.com)